### PR TITLE
New detector for finding division by zero errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 - Fixed False positives for `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` on try-with-resources with interface references ([#1931](https://github.com/spotbugs/spotbugs/issues/1931))
 - Disabled detector `ThrowingExceptions` by default to avoid many false positives ([#2040](https://github.com/spotbugs/spotbugs/issues/2040))
 
+### Added
+- New detector `FindDivisionByZero` for detecting `DZ_DIVISION_BY_ZERO`. Current implementation only detects very basic cases. Enhancements to the value range analysis will result in detecting more advanced cases.
+
 ## 4.7.0 - 2022-04-14
 ### Changed
 - Updated documentation by adding parenthesis `()` to the negative odd check message ([#1995](https://github.com/spotbugs/spotbugs/issues/1995))

--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindDivisionByZeroTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindDivisionByZeroTest.java
@@ -1,0 +1,53 @@
+package edu.umd.cs.findbugs.detect;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+
+public class FindDivisionByZeroTest extends AbstractIntegrationTest {
+    @Test
+    public void testDivisionByZero() {
+        performAnalysis("DivisionByZero.class");
+
+        assertNumOfDZBugs(16);
+
+        assertDZBug("divByZeroIntParam", 7);
+        assertDZBug("divByZeroLongParam", 14);
+        assertDZBug("divByZeroIntParam2", 19);
+        assertDZBug("divByZeroLongParam2", 26);
+        assertDZBug("divByZeroIntParam3", 38);
+        assertDZBug("divByZeroLongParam3", 48);
+        assertDZBug("divByZeroIntParam4", 54);
+        assertDZBug("divByZeroLongParam4", 63);
+        assertDZBug("remByZeroIntParam", 73);
+        assertDZBug("remByZeroLongParam", 80);
+        assertDZBug("remByZeroIntParam2", 85);
+        assertDZBug("remByZeroLongParam2", 92);
+        assertDZBug("remByZeroIntParam3", 104);
+        assertDZBug("remByZeroLongParam3", 114);
+        assertDZBug("remByZeroIntParam4", 120);
+        assertDZBug("remByZeroLongParam4", 129);
+    }
+
+    private void assertNumOfDZBugs(int num) {
+        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("DZ_DIVISION_BY_ZERO").build();
+        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
+    }
+
+    private void assertDZBug(String method, int line) {
+        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType("DZ_DIVISION_BY_ZERO")
+                .inClass("DivisionByZero")
+                .inMethod(method)
+                .atLine(line)
+                .build();
+        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+    }
+}

--- a/spotbugs/etc/findbugs.xml
+++ b/spotbugs/etc/findbugs.xml
@@ -669,6 +669,8 @@
                     reports="PERM_SUPER_NOT_CALLED_IN_GETPERMISSIONS"/>
           <Detector class="edu.umd.cs.findbugs.detect.FindPotentialSecurityCheckBasedOnUntrustedSource" speed="fast"
                     reports="USC_POTENTIAL_SECURITY_CHECK_BASED_ON_UNTRUSTED_SOURCE"/>
+          <Detector class="edu.umd.cs.findbugs.detect.FindDivisionByZero"
+                    reports="DZ_DIVISION_BY_ZERO"/>
             <!-- Bug Categories -->
            <BugCategory category="NOISE" hidden="true"/>
 
@@ -1286,4 +1288,5 @@
           <BugPattern abbrev="PERM" type="PERM_SUPER_NOT_CALLED_IN_GETPERMISSIONS" category="MALICIOUS_CODE" />
           <BugPattern abbrev="USC" type="USC_POTENTIAL_SECURITY_CHECK_BASED_ON_UNTRUSTED_SOURCE"
                     category="MALICIOUS_CODE"/>
+          <BugPattern abbrev="DZ" type="DZ_DIVISION_BY_ZERO" category="CORRECTNESS" />
 </FindbugsPlugin>

--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -1769,6 +1769,15 @@ factory pattern to create these objects.</p>
       <![CDATA[
             <p>Looks for potential security checks on an untrusted source before entering a
                doPrivileged block.</p>
+               ]]>
+    </Details>
+  </Detector>
+  <Detector class="edu.umd.cs.findbugs.detect.FindDivisionByZero">
+    <Details>
+      <![CDATA[
+            <p>
+              Division by zero.
+            </p>
       ]]>
     </Details>
   </Detector>
@@ -8786,6 +8795,15 @@ Using floating-point variables should not be used as loop counters, as they are 
       </p>]]>
     </Details>
   </BugPattern>
+  <BugPattern type="DZ_DIVISION_BY_ZERO">
+    <ShortDescription>Division by zero</ShortDescription>
+    <LongDescription>Division by zero.</LongDescription>
+    <Details>
+      <![CDATA[<p>
+        Division by zero.
+      </p>]]>
+    </Details>
+  </BugPattern>
   <!--
   **********************************************************************
    BugCodes
@@ -8939,4 +8957,5 @@ Using floating-point variables should not be used as loop counters, as they are 
   <BugCode abbrev="THROWS">Exception throwing related problems</BugCode>
   <BugCode abbrev="PERM">Custom class loader does not call its superclass's getPermissions()</BugCode>
   <BugCode abbrev="USC">Potential security check based on untrusted source</BugCode>
+  <BugCode abbrev="DZ">Division by zero</BugCode>
 </MessageCollection>

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindDivisionByZero.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindDivisionByZero.java
@@ -1,0 +1,105 @@
+/*
+ * SpotBugs - Find Bugs in Java programs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package edu.umd.cs.findbugs.detect;
+
+import java.util.Iterator;
+
+import org.apache.bcel.classfile.Method;
+import org.apache.bcel.generic.IDIV;
+import org.apache.bcel.generic.IREM;
+import org.apache.bcel.generic.Instruction;
+import org.apache.bcel.generic.InstructionHandle;
+import org.apache.bcel.generic.LDIV;
+import org.apache.bcel.generic.LREM;
+
+import edu.umd.cs.findbugs.BugAccumulator;
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.Detector;
+import edu.umd.cs.findbugs.SourceLineAnnotation;
+import edu.umd.cs.findbugs.ba.CFG;
+import edu.umd.cs.findbugs.ba.CFGBuilderException;
+import edu.umd.cs.findbugs.ba.ClassContext;
+import edu.umd.cs.findbugs.ba.Location;
+import edu.umd.cs.findbugs.ba.LongRangeSet;
+import edu.umd.cs.findbugs.ba.ValueRangeDataflow;
+import edu.umd.cs.findbugs.ba.vna.ValueNumber;
+import edu.umd.cs.findbugs.ba.vna.ValueNumberDataflow;
+import edu.umd.cs.findbugs.ba.vna.ValueNumberFrame;
+import edu.umd.cs.findbugs.classfile.CheckedAnalysisException;
+
+public class FindDivisionByZero implements Detector {
+    private final BugAccumulator bugAccumulator;
+    private final BugReporter bugReporter;
+
+    public FindDivisionByZero(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+        this.bugAccumulator = new BugAccumulator(bugReporter);
+    }
+
+    @Override
+    public void visitClassContext(ClassContext classContext) {
+        for (Method method : classContext.getJavaClass().getMethods()) {
+            try {
+                analyzeMethod(classContext, method);
+            } catch (CFGBuilderException e) {
+                bugReporter.logError("Error finding locked call sites", e);
+                continue;
+            } catch (CheckedAnalysisException e) {
+                bugReporter.logError("ValueRangeAnalysis failed for " + method, e);
+                continue;
+            }
+        }
+    }
+
+    private void analyzeMethod(ClassContext classContext, Method method) throws CFGBuilderException,
+            CheckedAnalysisException {
+        ValueNumberDataflow vnaDataflow = classContext.getValueNumberDataflow(method);
+        ValueRangeDataflow vraDataflow = classContext.getValueRangeDataflow(method);
+        CFG cfg = classContext.getCFG(method);
+        for (Iterator<Location> i = cfg.locationIterator(); i.hasNext();) {
+            Location location = i.next();
+            InstructionHandle handle = location.getHandle();
+            Instruction ins = handle.getInstruction();
+            if (!(ins instanceof IDIV) && !(ins instanceof IREM) &&
+                    !(ins instanceof LDIV) && !(ins instanceof LREM)) {
+                continue;
+            }
+
+            ValueNumberFrame frame = vnaDataflow.getFactAtLocation(location);
+            ValueNumber divisorNumber = frame.getTopValue();
+            if (divisorNumber == null) {
+                continue;
+            }
+            LongRangeSet divisorRangeSet = vraDataflow.getFactAtLocation(location).getRange(divisorNumber);
+            if (divisorRangeSet.ne(0).isEmpty()) {
+                bugAccumulator.accumulateBug(new BugInstance("DZ_DIVISION_BY_ZERO", NORMAL_PRIORITY)
+                        .addClassAndMethod(classContext.getJavaClass(), method)
+                        .addSourceLine(classContext, method, location),
+                        SourceLineAnnotation.fromVisitedInstruction(classContext, method, handle));
+            }
+        }
+        bugAccumulator.reportAccumulatedBugs();
+    }
+
+    @Override
+    public void report() {
+        // TODO Auto-generated method stub
+    }
+}

--- a/spotbugsTestCases/src/java/DivisionByZero.java
+++ b/spotbugsTestCases/src/java/DivisionByZero.java
@@ -1,0 +1,178 @@
+public class DivisionByZero {
+
+    public int divByZeroIntParam(int n) {
+        if (n != 0) {
+            return 0;
+        }
+        return 1 / n;
+    }
+
+    public long divByZeroLongParam(long n) {
+        if (n != 0) {
+            return 0;
+        }
+        return 1 / n;
+    }
+
+    public int divByZeroIntParam2(int n) {
+        if (n == 0) {
+            return 1 / n;
+        }
+        return 0;
+    }
+
+    public long divByZeroLongParam2(long n) {
+        if (n == 0) {
+            return 1 / n;
+        }
+        return 0;
+    }
+
+    public int divByZeroIntParam3(int n) {
+        if (n < 0) {
+            return 0;
+        }
+        if (n > 0) {
+            return 0;
+        }
+        return 1 / n;
+    }
+
+    public long divByZeroLongParam3(long n) {
+        if (n < 0) {
+            return 0;
+        }
+        if (n > 0) {
+            return 0;
+        }
+        return 1 / n;
+    }
+
+    public int divByZeroIntParam4(int n) {
+        if (n <= 0) {
+            if (n >= 0) {
+                return 1 / n;
+            }
+        }
+        return 0;
+    }
+
+    public long divByZeroLongParam4(long n) {
+        if (n <= 0) {
+            if (n >= 0) {
+                return 1 / n;
+            }
+        }
+        return 0;
+    }
+
+    public int remByZeroIntParam(int n) {
+        if (n != 0) {
+            return 0;
+        }
+        return 1 % n;
+    }
+
+    public long remByZeroLongParam(long n) {
+        if (n != 0) {
+            return 0;
+        }
+        return 1 % n;
+    }
+
+    public int remByZeroIntParam2(int n) {
+        if (n == 0) {
+            return 1 % n;
+        }
+        return 0;
+    }
+
+    public long remByZeroLongParam2(long n) {
+        if (n == 0) {
+            return 1 % n;
+        }
+        return 0;
+    }
+
+    public int remByZeroIntParam3(int n) {
+        if (n < 0) {
+            return 0;
+        }
+        if (n > 0) {
+            return 0;
+        }
+        return 1 % n;
+    }
+
+    public long remByZeroLongParam3(long n) {
+        if (n < 0) {
+            return 0;
+        }
+        if (n > 0) {
+            return 0;
+        }
+        return 1 % n;
+    }
+
+    public int remByZeroIntParam4(int n) {
+        if (n <= 0) {
+            if (n >= 0) {
+                return 1 % n;
+            }
+        }
+        return 0;
+    }
+
+    public long remByZeroLongParam4(long n) {
+        if (n <= 0) {
+            if (n >= 0) {
+                return 1 % n;
+            }
+        }
+        return 0;
+    }
+
+    /* Negative tests */
+
+    public int divByNonZeroIntParam(int n) {
+        return 1 / n;
+    }
+
+    public long divByNonZeroLongParam(long n) {
+        return 1 / n;
+    }
+
+    public int divByNonZeroIntParam2(int n) {
+        if (n > 0) {
+            return 0;
+        }
+        return 1 / n;
+    }
+
+    public int divByNonZeroIntParam3(int n) {
+        if (n >= 0) {
+            return 1 / n;
+        }
+        return 0;
+    }
+
+    public int divByNonZeroIntParam4(int n) {
+        if (n >= 0) {
+            if (n <= 1) {
+                return 1 / n;    // n in [0..1]
+            }
+        }
+        return 0;
+    }
+
+
+    public int divByNonZeroIntParam5(int n) {
+        if (n > 1) {
+            return 0;
+        }
+        if (n < 0) {
+            return 0;
+        }
+        return 1 / n;    // n in [0..1]
+    }
+}


### PR DESCRIPTION
A new detector `FindDivisionByZero` detects cases where the divisor is zero. The error message is `DZ_DIVISION_BY_ZERO`.
Currently, only very straightforward cases are detected. However, if the new data-flow based `ValueRangeAnalysis` is
enhanced then more advanced cases are automatically detected without the need of changing this detector.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [X] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
