### PR TITLE
ValueRangeAnalysis: set up (single length) ranges for constants

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/ValueRangeDataflowTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/ba/ValueRangeDataflowTest.java
@@ -68,6 +68,9 @@ public class ValueRangeDataflowTest extends AbstractIntegrationTest {
 
             } else if ("Method: ValueRangeDataflow.otherRange(int, short)".equals(outputLines[i])) {
                 checkOtherRange(outputLines, i + 4);
+
+            } else if ("Method: ValueRangeDataflow.constant()".equals(outputLines[i])) {
+                checkConstant(outputLines, i + 4);
             }
         }
     }
@@ -245,6 +248,16 @@ public class ValueRangeDataflowTest extends AbstractIntegrationTest {
                         Integer.MAX_VALUE + "\\].*"));
                 assertTrue(outputLines[i].matches("BASIC BLOCK: 5 Variable ranges:.*\\[" + Short.MIN_VALUE + ", " +
                         Short.MAX_VALUE + "\\].*"));
+                return;
+            }
+        }
+        assertTrue(false);
+    }
+
+    private void checkConstant(String[] outputLines, int n) {
+        for (int i = n; i < outputLines.length; ++i) {
+            if (outputLines[i].length() >= 9 && "EDGE(1)".equals(outputLines[i].substring(2, 9))) {
+                assertTrue(outputLines[i].matches("  EDGE\\(1\\) type RETURN.*Variable ranges:.*\\{100\\}.*"));
                 return;
             }
         }

--- a/spotbugsTestCases/src/java/ValueRangeDataflow.java
+++ b/spotbugsTestCases/src/java/ValueRangeDataflow.java
@@ -116,4 +116,11 @@ public class ValueRangeDataflow {
          }
          return n + m + k;
      }
+
+     // Constants
+
+     int constant() {
+         int n = 100;
+         return n;
+     }
 }


### PR DESCRIPTION
Constants are the most natural values whose range we know: a range of length 1 which is the value of the constant itself. This PR implements this functionality in `ValueRangeAnalysis`.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
