### PR TITLE
Small fixes to ASE_ASSERTION_WITH_SIDE_EFFECT (SEI_CERT_EXP06_J)

### DIFF
--- a/spotbugs/etc/messages.xml
+++ b/spotbugs/etc/messages.xml
@@ -8794,7 +8794,7 @@ Using floating-point variables should not be used as loop counters, as they are 
 
   <BugPattern type="ASE_ASSERTION_WITH_SIDE_EFFECT">
     <ShortDescription>Expression in assertion may produce a side effect</ShortDescription>
-    <LongDescription> The expression used in assertion at {1} may produce a side effect. If assertions are disabled, the expression won't get executed and the result of the method might change.</LongDescription>
+    <LongDescription>The expression used in assertion at {1} may produce a side effect. If assertions are disabled, the expression won't get executed and the result of the method might change.</LongDescription>
     <Details>
       <![CDATA[
             <p>Expressions used in assertions must not produce side effects.</p>
@@ -8811,7 +8811,7 @@ Using floating-point variables should not be used as loop counters, as they are 
     <LongDescription>The method called in assertion at {1} may produce a side effect. If assertions are disabled, the method invocation won't get executed and the result of the method might change.</LongDescription>
     <Details>
       <![CDATA[
-            <p>Expressions used in assertions must not produce side effect.</p>
+            <p>Expressions used in assertions must not produce side effects.</p>
 
             <p>See <https://wiki.sei.cmu.edu/confluence/display/java/EXP06-J.+Expressions+used+in+assertions+must+not+produce+side+effects><code>SEI CERT Rule EXP06</code></a>
             for more information.

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindAssertionsWithSideEffects.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindAssertionsWithSideEffects.java
@@ -47,7 +47,7 @@ public class FindAssertionsWithSideEffects extends AbstractAssertDetector {
             String retSig = new SignatureParser(getXMethodOperand().getSignature()).getReturnTypeSignature();
             String classSig = getXClassOperand().getSourceSignature();
             if (MutableClasses.mutableSignature("L" + getClassConstantOperand() + ";") &&
-                    MutableClasses.looksLikeASetter(getNameConstantOperand(), retSig, classSig)) {
+                    MutableClasses.looksLikeASetter(getNameConstantOperand(), classSig, retSig)) {
                 BugInstance bug = new BugInstance(this, "ASE_ASSERTION_WITH_SIDE_EFFECT_METHOD", LOW_PRIORITY)
                         .addClassAndMethod(this)
                         .addSourceLine(this, getPC());


### PR DESCRIPTION
Small fixes according to the comments of the relevant [PR in the spotbugs/spotbugs repository](https://github.com/spotbugs/spotbugs/pull/2130).


----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
