### PR TITLE
Add license header to FindAssertionsWithSideEffects

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/AbstractAssertDetector.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/AbstractAssertDetector.java
@@ -1,3 +1,21 @@
+/*
+ * SpotBugs - Find bugs in Java programs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
 package edu.umd.cs.findbugs.detect;
 
 import org.apache.bcel.Const;

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindAssertionsWithSideEffects.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindAssertionsWithSideEffects.java
@@ -1,3 +1,21 @@
+/*
+ * SpotBugs - Find bugs in Java programs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
 package edu.umd.cs.findbugs.detect;
 
 import org.apache.bcel.Const;


### PR DESCRIPTION
Added missing license header to the new source files in the spotbugs directory.
The relevant PR in spotbugs: https://github.com/spotbugs/spotbugs/pull/2130

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
