### PR TITLE
FixIssue2042 - Rewrite the tests to the newer type, rename

### DIFF
--- a/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindReturnRefTest.java
+++ b/spotbugs-tests/src/test/java/edu/umd/cs/findbugs/detect/FindReturnRefTest.java
@@ -1,0 +1,210 @@
+package edu.umd.cs.findbugs.detect;
+
+import edu.umd.cs.findbugs.AbstractIntegrationTest;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.junit.Test;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+public class FindReturnRefTest extends AbstractIntegrationTest {
+    @Test
+    public void testFindReturnRefTestChecks() {
+        performAnalysis("FindReturnRefTest.class");
+
+        assertNumOfBugs("EI_EXPOSE_BUF", 2);
+        assertNumOfBugs("EI_EXPOSE_BUF2", 2);
+        assertNumOfBugs("EI_EXPOSE_REP", 6);
+        assertNumOfBugs("EI_EXPOSE_REP2", 6);
+        assertNumOfBugs("EI_EXPOSE_STATIC_BUF2", 2);
+        assertNumOfBugs("EI_EXPOSE_STATIC_REP2", 6);
+        assertNumOfBugs("MS_EXPOSE_BUF", 2);
+        assertNumOfBugs("MS_EXPOSE_REP", 6);
+
+        assertBug("EI_EXPOSE_BUF", "FindReturnRefTest", "getBuferWrap", "charArray");
+        assertBug("EI_EXPOSE_BUF", "FindReturnRefTest", "getBufferDuplicate", "charBuf");
+
+        assertBug("EI_EXPOSE_BUF2", "FindReturnRefTest", "setBufferDuplicate", "charBuf");
+        assertBug("EI_EXPOSE_BUF2", "FindReturnRefTest", "setBufferWrap", "charBuf");
+
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest", "getBuffer", "charBuf");
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest", "getDate", "date");
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest", "getDate2", "date");
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest", "getDateArray", "dateArray");
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest", "getValues", "hm");
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest", "getDateArray2", "dateArray");
+
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest", "setBuffer", "charBuf");
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest", "setDate", "date");
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest", "setDate2", "date");
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest", "setDateArray", "dateArray");
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest", "setValues", "hm");
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest", "setDateArray2", "dateArray");
+
+        assertBug("EI_EXPOSE_STATIC_BUF2", "FindReturnRefTest", "setStaticBufferDuplicate", "sCharBuf");
+        assertBug("EI_EXPOSE_STATIC_BUF2", "FindReturnRefTest", "setStaticBufferWrap", "sCharBuf");
+
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "getStaticValues", "shm");
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "setStaticBuffer", "sCharBuf");
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "setStaticDate", "sDate");
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "setStaticDate2", "sDate");
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "setStaticDateArray", "sDateArray");
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest", "setStaticDateArray2", "sDateArray");
+
+        assertBug("MS_EXPOSE_BUF", "FindReturnRefTest", "getStaticBuferWrap", "sCharArray");
+        assertBug("MS_EXPOSE_BUF", "FindReturnRefTest", "getStaticBufferDuplicate", "sCharBuf");
+
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticBuffer", "sCharBuf");
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticDate", "sDate");
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticDate2", "sDate");
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticDateArray", "sDateArray");
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticValues", "shm");
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest", "getStaticDateArray2", "sDateArray");
+
+    }
+
+    @Test
+    public void testFindReturnRefTest2Checks() {
+        performAnalysis("FindReturnRefTest2.class",
+                "FindReturnRefTest2$Nested.class",
+                "FindReturnRefTest2$Inner.class");
+
+        assertNumOfBugs("EI_EXPOSE_BUF", 2);
+        assertNumOfBugs("EI_EXPOSE_BUF2", 2);
+        assertNumOfBugs("EI_EXPOSE_REP", 6);
+        assertNumOfBugs("EI_EXPOSE_REP2", 6);
+        assertNumOfBugs("EI_EXPOSE_STATIC_BUF2", 2);
+        assertNumOfBugs("EI_EXPOSE_STATIC_REP2", 6);
+        assertNumOfBugs("MS_EXPOSE_BUF", 2);
+        assertNumOfBugs("MS_EXPOSE_REP", 6);
+
+        assertBug("EI_EXPOSE_BUF", "FindReturnRefTest2$Inner", "getBuferWrap", "charArray");
+        assertBug("EI_EXPOSE_BUF", "FindReturnRefTest2$Inner", "getBufferDuplicate", "charBuf");
+
+        assertBug("EI_EXPOSE_BUF2", "FindReturnRefTest2$Inner", "setBufferDuplicate", "access$802");
+        assertBug("EI_EXPOSE_BUF2", "FindReturnRefTest2$Inner", "setBufferWrap", "access$802");
+
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest2$Inner", "getBuffer", "charBuf");
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest2$Inner", "getDate", "date");
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest2$Inner", "getDate2", "date");
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest2$Inner", "getDateArray", "dateArray");
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest2$Inner", "getValues", "hm");
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest2$Inner", "getDateArray2", "dateArray");
+
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest2$Inner", "setBuffer", "access$802");
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest2$Inner", "setDate", "access$502");
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest2$Inner", "setDate2", "access$502");
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest2$Inner", "setDateArray", "access$602");
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest2$Inner", "setValues", "access$702");
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest2$Inner", "setDateArray2", "access$602");
+
+        assertBug("EI_EXPOSE_STATIC_BUF2", "FindReturnRefTest2$Nested", "setStaticBufferDuplicate", "access$302");
+        assertBug("EI_EXPOSE_STATIC_BUF2", "FindReturnRefTest2$Nested", "setStaticBufferWrap", "access$302");
+
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest2$Nested", "setStaticBuffer", "access$302");
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest2$Nested", "setStaticDate", "access$002");
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest2$Nested", "setStaticDate2", "access$002");
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest2$Nested", "setStaticDateArray", "access$102");
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest2$Nested", "setStaticValues", "access$202");
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest2$Nested", "setStaticDateArray2", "access$102");
+
+        assertBug("MS_EXPOSE_BUF", "FindReturnRefTest2$Nested", "getStaticBuferWrap", "sCharArray");
+        assertBug("MS_EXPOSE_BUF", "FindReturnRefTest2$Nested", "getStaticBufferDuplicate", "sCharBuf");
+
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest2$Nested", "getStaticBuffer", "sCharBuf");
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest2$Nested", "getStaticDate", "sDate");
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest2$Nested", "getStaticDate2", "sDate");
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest2$Nested", "getStaticDateArray", "sDateArray");
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest2$Nested", "getStaticValues", "shm");
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest2$Nested", "getStaticDateArray2", "sDateArray");
+
+    }
+
+    @Test
+    public void testFindReturnRefTest3Checks() {
+        performAnalysis("FindReturnRefTest3.class",
+                "FindReturnRefTest3$Nested.class");
+
+        assertNumOfBugs("EI_EXPOSE_BUF", 2);
+        assertNumOfBugs("EI_EXPOSE_BUF2", 2);
+        assertNumOfBugs("EI_EXPOSE_REP", 6);
+        assertNumOfBugs("EI_EXPOSE_REP2", 6);
+        assertNumOfBugs("EI_EXPOSE_STATIC_BUF2", 2);
+        assertNumOfBugs("EI_EXPOSE_STATIC_REP2", 6);
+        assertNumOfBugs("MS_EXPOSE_BUF", 2);
+        assertNumOfBugs("MS_EXPOSE_REP", 6);
+
+        assertBug("EI_EXPOSE_BUF", "FindReturnRefTest3$Nested", "getBuferWrap", "charArray");
+        assertBug("EI_EXPOSE_BUF", "FindReturnRefTest3$Nested", "getBufferDuplicate", "charBuf");
+
+        assertBug("EI_EXPOSE_BUF2", "FindReturnRefTest3$Nested", "setBufferDuplicate", "charBuf");
+        assertBug("EI_EXPOSE_BUF2", "FindReturnRefTest3$Nested", "setBufferWrap", "charBuf");
+
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest3$Nested", "getBuffer", "charBuf");
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest3$Nested", "getDate", "date");
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest3$Nested", "getDate2", "date");
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest3$Nested", "getDateArray", "dateArray");
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest3$Nested", "getValues", "hm");
+        assertBug("EI_EXPOSE_REP", "FindReturnRefTest3$Nested", "getDateArray2", "dateArray");
+
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest3$Nested", "setBuffer", "charBuf");
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest3$Nested", "setDate", "date");
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest3$Nested", "setDate2", "date");
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest3$Nested", "setDateArray", "dateArray");
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest3$Nested", "setValues", "hm");
+        assertBug("EI_EXPOSE_REP2", "FindReturnRefTest3$Nested", "setDateArray2", "dateArray");
+
+        assertBug("EI_EXPOSE_STATIC_BUF2", "FindReturnRefTest3$Nested", "setStaticBufferDuplicate", "sCharBuf");
+        assertBug("EI_EXPOSE_STATIC_BUF2", "FindReturnRefTest3$Nested", "setStaticBufferWrap", "sCharBuf");
+
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest3$Nested", "setStaticBuffer", "sCharBuf");
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest3$Nested", "setStaticDate", "sDate");
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest3$Nested", "setStaticDate2", "sDate");
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest3$Nested", "setStaticDateArray", "sDateArray");
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest3$Nested", "setStaticValues", "shm");
+        assertBug("EI_EXPOSE_STATIC_REP2", "FindReturnRefTest3$Nested", "setStaticDateArray2", "sDateArray");
+
+        assertBug("MS_EXPOSE_BUF", "FindReturnRefTest3$Nested", "getStaticBuferWrap", "sCharArray");
+        assertBug("MS_EXPOSE_BUF", "FindReturnRefTest3$Nested", "getStaticBufferDuplicate", "sCharBuf");
+
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest3$Nested", "getStaticBuffer", "sCharBuf");
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest3$Nested", "getStaticDate", "sDate");
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest3$Nested", "getStaticDate2", "sDate");
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest3$Nested", "getStaticDateArray", "sDateArray");
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest3$Nested", "getStaticValues", "shm");
+        assertBug("MS_EXPOSE_REP", "FindReturnRefTest3$Nested", "getStaticDateArray2", "sDateArray");
+    }
+
+    @Test
+    public void testFindReturnRefTestNegativeChecks() {
+        performAnalysis("FindReturnRefNegativeTest.class",
+                "FindReturnRefNegativeTest$Inner.class");
+
+        assertNumOfBugs("EI_EXPOSE_BUF", 0);
+        assertNumOfBugs("EI_EXPOSE_BUF2", 0);
+        assertNumOfBugs("EI_EXPOSE_REP", 0);
+        assertNumOfBugs("EI_EXPOSE_REP2", 0);
+        assertNumOfBugs("EI_EXPOSE_STATIC_BUF2", 0);
+        assertNumOfBugs("EI_EXPOSE_STATIC_REP2", 0);
+        assertNumOfBugs("MS_EXPOSE_BUF", 0);
+        assertNumOfBugs("MS_EXPOSE_REP", 0);
+    }
+
+    private void assertNumOfBugs(String bugtype, int num) {
+        final BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType(bugtype).build();
+        assertThat(getBugCollection(), containsExactly(num, bugTypeMatcher));
+    }
+
+    private void assertBug(String bugtype, String className, String method, String field) {
+        final BugInstanceMatcher bugInstanceMatcher = new BugInstanceMatcherBuilder()
+                .bugType(bugtype)
+                .inClass(className)
+                .inMethod(method)
+                .atField(field)
+                .build();
+        assertThat(getBugCollection(), hasItem(bugInstanceMatcher));
+    }
+}

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/FindReturnRef.java
@@ -424,30 +424,30 @@ public class FindReturnRef extends OpcodeStackDetector {
 
     }
 
-    private boolean isFieldOf(XField field, ClassDescriptor klass) {
+    private boolean isFieldOf(XField field, ClassDescriptor clazz) {
         do {
-            ClassDescriptor klass2 = klass;
+            ClassDescriptor clazz2 = clazz;
             do {
-                if (field.getClassDescriptor().equals(klass2)) {
+                if (field.getClassDescriptor().equals(clazz2)) {
                     return true;
                 }
                 try {
-                    klass2 = klass2.getXClass().getSuperclassDescriptor();
+                    clazz2 = clazz2.getXClass().getSuperclassDescriptor();
                 } catch (CheckedAnalysisException e) {
-                    AnalysisContext.logError("Error checking for class " + klass2, e);
+                    AnalysisContext.logError("Error checking for class " + clazz2, e);
                     return false;
                 }
-            } while (klass2 != null);
+            } while (clazz2 != null);
             try {
-                klass = klass.getXClass().getImmediateEnclosingClass();
-                if (klass != null && !klass.getXClass().isPublic()) {
+                clazz = clazz.getXClass().getImmediateEnclosingClass();
+                if (clazz != null && !clazz.getXClass().isPublic()) {
                     return false;
                 }
             } catch (CheckedAnalysisException e) {
-                AnalysisContext.logError("Error checking for class " + klass, e);
+                AnalysisContext.logError("Error checking for class " + clazz, e);
                 return false;
             }
-        } while (klass != null);
+        } while (clazz != null);
         return false;
     }
 }

--- a/spotbugsTestCases/src/java/FindReturnRefNegativeTest.java
+++ b/spotbugsTestCases/src/java/FindReturnRefNegativeTest.java
@@ -65,17 +65,14 @@ public class FindReturnRefNegativeTest {
 
     // Correct solutions to return private fields:
 
-    @NoWarning("EI")
     public Date getDate() {
         return (Date) date.clone();
     }
 
-    @NoWarning("MS")
     public static Date getStaticDate() {
         return (Date) sDate.clone();
     }
 
-    @NoWarning("EI")
     public Date[] getDateArray() {
         Date[] dateCopy = new Date[dateArray.length];
         for (int i = 0; i < dateArray.length; i++) {
@@ -84,7 +81,6 @@ public class FindReturnRefNegativeTest {
         return dateCopy;
     }
 
-    @NoWarning("MS")
     public static Date[] getStaticDateArray() {
         Date[] dateCopy = new Date[sDateArray.length];
         for (int i = 0; i < sDateArray.length; i++) {
@@ -93,83 +89,68 @@ public class FindReturnRefNegativeTest {
         return dateCopy;
     }
 
-    @NoWarning("EI")
     public HashMap<Integer, String> getValues() {
         return (HashMap<Integer, String>) hm.clone();
     }
 
-    @NoWarning("MS")
     public static HashMap<Integer, String> getStaticValues() {
         return (HashMap<Integer, String>) shm.clone();
     }
 
     // Returning public case should be OK.
 
-    @NoWarning("EI")
     public Date getPublicDate() {
         return pubDate;
     }
 
-    @NoWarning("MS")
     public static Date getPublicStaticDate() {
         return pubSDate;
     }
 
-    @NoWarning("EI")
     public Date[] getPublicDateArray() {
         return pubDateArray;
     }
 
-    @NoWarning("MS")
     public static Date[] getPublicStaticDateArray() {
         return pubSDateArray;
     }
 
-    @NoWarning("EI")
     public HashMap<Integer, String> getPublicValues() {
         return puhm;
     }
 
-    @NoWarning("MS")
     public static HashMap<Integer, String> getPublicStaticValues() {
         return pushm;
     }
 
     // Returning a private immutable should be OK.
 
-    @NoWarning("EI")
     public String getString() {
         return string;
     }
 
-    @NoWarning("MS")
     public static String getStaticString() {
         return sString;
     }
 
-    @NoWarning("EI")
     public String[] getStringArray() {
         return stringArray.clone();
     }
 
-    @NoWarning("MS")
     public static String[] getStaticStringArray() {
         return sStringArray.clone();
     }
 
     // Correct solutions to store mutable objects in fields:
 
-    @NoWarning("EI2")
     public void setDate(Date d) {
         date = (Date) d.clone();
     }
 
-    @NoWarning("MS")
     public static void setStaticDate(Date d) {
         sDate = (Date) d.clone();
     }
 
-    @NoWarning("EI2")
     public void setDateArray(Date[] da) {
         dateArray = new Date[da.length];
         for (int i = 0; i < da.length; i++) {
@@ -177,7 +158,6 @@ public class FindReturnRefNegativeTest {
         }
     }
 
-    @NoWarning("MS")
     public static void setStaticDateArray(Date[] da) {
         sDateArray = new Date[da.length];
         for (int i = 0; i < da.length; i++) {
@@ -185,19 +165,16 @@ public class FindReturnRefNegativeTest {
         }
     }
 
-    @NoWarning("EI2")
     public void setValues(HashMap<Integer, String> values) {
         hm = (HashMap<Integer, String>) values.clone();
     }
 
-    @NoWarning("MS")
     public static void getStaticValues(HashMap<Integer, String>  values) {
         shm = (HashMap<Integer, String>) values.clone();
     }
 
     // Do not warn for synthetic methods.
 
-    @NoWarning("EI")
     private class Inner {
         private void accessParent() {
             Date d1 = date;
@@ -212,36 +189,30 @@ public class FindReturnRefNegativeTest {
     private static CharBuffer sCharBuf;
     private static char[] sCharArray;
 
-    @NoWarning("EI")
     public CharBuffer getBufferReadOnly() {
         return charBuf.asReadOnlyBuffer();
     }
 
-    @NoWarning("MS")
     public static CharBuffer getStaticBufferReadOnly() {
         return sCharBuf.asReadOnlyBuffer();
     }
 
-    @NoWarning("EI")
     public CharBuffer getBufferCopy() {
         CharBuffer cb = CharBuffer.allocate(charArray.length);
         cb.put(charArray);
         return cb;
     }
 
-    @NoWarning("MS")
     public static CharBuffer getStaticBufferCopy() {
         CharBuffer cb = CharBuffer.allocate(sCharArray.length);
         cb.put(sCharArray);
         return cb;
     }
 
-    @NoWarning("EI")
     public CharBuffer getBuferWrap() {
         return CharBuffer.wrap(charArray).asReadOnlyBuffer();        
     }
 
-    @NoWarning("MS")
     public static CharBuffer getStaticBuferWrap() {
         return CharBuffer.wrap(sCharArray).asReadOnlyBuffer();        
     }

--- a/spotbugsTestCases/src/java/FindReturnRefTest.java
+++ b/spotbugsTestCases/src/java/FindReturnRefTest.java
@@ -32,108 +32,96 @@ public class FindReturnRefTest {
 
     // Returning a private mutable object reference attribute is dangerous.
 
-    @ExpectWarning("EI")
     public Date getDate() {
         return date;
     }
 
-    @ExpectWarning("MS")
     public static Date getStaticDate() {
         return sDate;
     }
 
-    @ExpectWarning("EI") // Indirect way of returning reference
+    // Indirect way of returning reference
     public Date getDate2() {
         Date d = date;
         return d;
     }
 
-    @ExpectWarning("MS") // Indirect way of returning reference
+    // Indirect way of returning reference
     public static Date getStaticDate2() {
         Date d = sDate;
         return d;
     }
 
-    @ExpectWarning("EI")
     public Date[] getDateArray() {
         return dateArray;
     }
 
-    @ExpectWarning("MS")
     public static Date[] getStaticDateArray() {
         return sDateArray;
     }
 
-    @ExpectWarning("EI") // Cloning the array does not perform deep copy
+    // Cloning the array does not perform deep copy
     public Date[] getDateArray2() {
         return dateArray.clone();
     }
 
-    @ExpectWarning("MS") // Cloning the array does not perform deep copy
+    // Cloning the array does not perform deep copy
     public static Date[] getStaticDateArray2() {
         return sDateArray.clone();
     }
 
-    @ExpectWarning("EI")
     public HashMap<Integer, String> getValues() {
         return hm;
     }
 
-    @ExpectWarning("MS")
     public static HashMap<Integer, String> getStaticValues() {
         return shm;
     }
 
-    @ExpectWarning("EI2")
     public void setDate(Date d) {
         date = d;
     }
 
-    @ExpectWarning("MS")
     public static void setStaticDate(Date d) {
         sDate = d;
     }
 
     // Storing a reference to a mutable object is dangerous.
 
-    @ExpectWarning("EI2") // Indirect way of storing reference
+    // Indirect way of storing reference
     public void setDate2(Date d) {
         Date d2 = d;
         date = d2;
     }
 
-    @ExpectWarning("MS") // Indirect way of storing reference
+    // Indirect way of storing reference
     public static void setStaticDate2(Date d) {
         Date d2 = d;
         sDate = d;
     }
 
-    @ExpectWarning("EI2")
     public void setDateArray(Date[] da) {
         dateArray = da;
     }
 
-    @ExpectWarning("MS")
     public static void setStaticDateArray(Date[] da) {
         sDateArray = da;
     }
 
-    @ExpectWarning("EI2") // Cloning the array does not perform deep copy
+    // Cloning the array does not perform deep copy
     public void setDateArray2(Date[] da) {
         dateArray = da.clone();
     }
 
-    @ExpectWarning("MS") // Cloning the array does not perform deep copy
+    // Cloning the array does not perform deep copy
     public static void setStaticDateArray2(Date[] da) {
         sDateArray = da.clone();
     }
 
-    @ExpectWarning("EI2")
     public void setValues(HashMap<Integer, String> values) {
         hm = values;
     }
 
-    @ExpectWarning("MS")
     public static void getStaticValues(HashMap<Integer, String>  values) {
         shm = values;
     }
@@ -144,62 +132,50 @@ public class FindReturnRefTest {
     private static CharBuffer sCharBuf;
     private static char[] sCharArray;
 
-    @ExpectWarning("EI")
     public CharBuffer getBuffer() {
         return charBuf;
     }
 
-    @ExpectWarning("MS")
     public static CharBuffer getStaticBuffer() {
         return sCharBuf;
     }
 
-    @ExpectWarning("EI")
     public CharBuffer getBufferDuplicate() {
         return charBuf.duplicate();
     }
 
-    @ExpectWarning("MS")
     public static CharBuffer getStaticBufferDuplicate() {
         return sCharBuf.duplicate();
     }
 
-    @ExpectWarning("EI")
     public CharBuffer getBuferWrap() {
         return CharBuffer.wrap(charArray);        
     }
 
-    @ExpectWarning("MS")
     public static CharBuffer getStaticBuferWrap() {
         return CharBuffer.wrap(sCharArray);        
     }
 
-    @ExpectWarning("EI2")
     public void setBuffer(CharBuffer cb) {
         charBuf = cb;
     }
 
-    @ExpectWarning("MS")
     public static void setStaticBuffer(CharBuffer cb) {
         sCharBuf = cb;
     }
 
-    @ExpectWarning("EI2")
     public void setBufferDuplicate(CharBuffer cb) {
         charBuf = cb.duplicate();
     }
 
-    @ExpectWarning("MS")
     public static void setStaticBufferDuplicate(CharBuffer cb) {
         sCharBuf = cb.duplicate();
     }
 
-    @ExpectWarning("EI2")
     public void setBufferWrap(char[] cArr) {
         charBuf = CharBuffer.wrap(cArr);
     }
 
-    @ExpectWarning("MS")
     public static void setStaticBufferWrap(char[] cArr) {
         sCharBuf = CharBuffer.wrap(cArr);
     }

--- a/spotbugsTestCases/src/java/FindReturnRefTest2.java
+++ b/spotbugsTestCases/src/java/FindReturnRefTest2.java
@@ -39,86 +39,74 @@ public class FindReturnRefTest2 {
     public static class Nested {
         // Returning a private mutable object reference attribute is dangerous.
 
-        @ExpectWarning("MS")
         public static Date getStaticDate() {
             return sDate;
         }
 
-        @ExpectWarning("MS") // Indirect way of returning reference
+        // Indirect way of returning reference
         public static Date getStaticDate2() {
             Date d = sDate;
             return d;
         }
 
-        @ExpectWarning("MS")
         public static Date[] getStaticDateArray() {
             return sDateArray;
         }
 
-        @ExpectWarning("MS") // Cloning the array does not perform deep copy
+        // Cloning the array does not perform deep copy
         public static Date[] getStaticDateArray2() {
             return sDateArray.clone();
         }
 
-        @ExpectWarning("MS")
         public static HashMap<Integer, String> getStaticValues() {
             return shm;
         }
 
-        @ExpectWarning("MS")
         public static void setStaticDate(Date d) {
             sDate = d;
         }
 
         // Storing a reference to a mutable object is dangerous.
 
-        @ExpectWarning("MS") // Indirect way of storing reference
+        // Indirect way of storing reference
         public static void setStaticDate2(Date d) {
             Date d2 = d;
             sDate = d;
         }
 
-        @ExpectWarning("MS")
         public static void setStaticDateArray(Date[] da) {
             sDateArray = da;
         }
 
-        @ExpectWarning("MS") // Cloning the array does not perform deep copy
+        // Cloning the array does not perform deep copy
         public static void setStaticDateArray2(Date[] da) {
             sDateArray = da.clone();
         }
 
-        @ExpectWarning("MS")
         public static void setStaticValues(HashMap<Integer, String>  values) {
             shm = values;
         }
 
-        @ExpectWarning("MS")
         public static CharBuffer getStaticBuffer() {
             return sCharBuf;
         }
 
-        @ExpectWarning("MS")
         public static CharBuffer getStaticBufferDuplicate() {
             return sCharBuf.duplicate();
         }
 
-        @ExpectWarning("MS")
         public static CharBuffer getStaticBuferWrap() {
             return CharBuffer.wrap(sCharArray);        
         }
 
-        @ExpectWarning("MS")
         public static void setStaticBuffer(CharBuffer cb) {
             sCharBuf = cb;
         }
 
-        @ExpectWarning("MS")
         public static void setStaticBufferDuplicate(CharBuffer cb) {
             sCharBuf = cb.duplicate();
         }
 
-        @ExpectWarning("MS")
         public static void setStaticBufferWrap(char[] cArr) {
             sCharBuf = CharBuffer.wrap(cArr);
         }
@@ -127,86 +115,74 @@ public class FindReturnRefTest2 {
     public class Inner {
         // Returning a private mutable object reference attribute is dangerous.
 
-        @ExpectWarning("EI")
         public Date getDate() {
             return date;
         }
 
-        @ExpectWarning("EI") // Indirect way of returning reference
+        // Indirect way of returning reference
         public Date getDate2() {
             Date d = date;
             return d;
         }
 
-        @ExpectWarning("EI")
         public Date[] getDateArray() {
             return dateArray;
         }
 
-        @ExpectWarning("EI") // Cloning the array does not perform deep copy
+        // Cloning the array does not perform deep copy
         public Date[] getDateArray2() {
             return dateArray.clone();
         }
 
-        @ExpectWarning("EI")
         public HashMap<Integer, String> getValues() {
             return hm;
         }
 
-        @ExpectWarning("EI2")
         public void setDate(Date d) {
             date = d;
         }
 
         // Storing a reference to a mutable object is dangerous.
 
-        @ExpectWarning("EI2") // Indirect way of storing reference
+        // Indirect way of storing reference
         public void setDate2(Date d) {
             Date d2 = d;
             date = d2;
         }
 
-        @ExpectWarning("EI2")
         public void setDateArray(Date[] da) {
             dateArray = da;
         }
 
-        @ExpectWarning("EI2") // Cloning the array does not perform deep copy
+        // Cloning the array does not perform deep copy
         public void setDateArray2(Date[] da) {
             dateArray = da.clone();
         }
 
-        @ExpectWarning("EI2")
         public void setValues(HashMap<Integer, String> values) {
             hm = values;
         }
 
-        @ExpectWarning("EI")
         public CharBuffer getBuffer() {
             return charBuf;
         }
 
-        @ExpectWarning("EI")
         public CharBuffer getBufferDuplicate() {
             return charBuf.duplicate();
         }
 
-        @ExpectWarning("EI")
         public CharBuffer getBuferWrap() {
             return CharBuffer.wrap(charArray);        
         }
 
-        @ExpectWarning("EI2")
         public void setBuffer(CharBuffer cb) {
             charBuf = cb;
         }
 
-        @ExpectWarning("EI2")
         public void setBufferDuplicate(CharBuffer cb) {
             charBuf = cb.duplicate();
         }
 
-        @ExpectWarning("EI2")
         public void setBufferWrap(char[] cArr) {
             charBuf = CharBuffer.wrap(cArr);
         }

--- a/spotbugsTestCases/src/java/FindReturnRefTest3.java
+++ b/spotbugsTestCases/src/java/FindReturnRefTest3.java
@@ -40,170 +40,146 @@ public class FindReturnRefTest3 {
     
         // Returning a private mutable object reference attribute is dangerous.
 
-        @ExpectWarning("MS")
         public static Date getStaticDate() {
             return sDate;
         }
 
-        @ExpectWarning("MS") // Indirect way of returning reference
+        // Indirect way of returning reference
         public static Date getStaticDate2() {
             Date d = sDate;
             return d;
         }
 
-        @ExpectWarning("MS")
         public static Date[] getStaticDateArray() {
             return sDateArray;
         }
 
-        @ExpectWarning("MS") // Cloning the array does not perform deep copy
+        // Cloning the array does not perform deep copy
         public static Date[] getStaticDateArray2() {
             return sDateArray.clone();
         }
 
-        @ExpectWarning("MS")
         public static HashMap<Integer, String> getStaticValues() {
             return shm;
         }
 
-        @ExpectWarning("MS")
         public static void setStaticDate(Date d) {
             sDate = d;
         }
 
         // Storing a reference to a mutable object is dangerous.
 
-        @ExpectWarning("MS") // Indirect way of storing reference
+        // Indirect way of storing reference
         public static void setStaticDate2(Date d) {
             Date d2 = d;
             sDate = d;
         }
 
-        @ExpectWarning("MS")
         public static void setStaticDateArray(Date[] da) {
             sDateArray = da;
         }
 
-        @ExpectWarning("MS") // Cloning the array does not perform deep copy
+        // Cloning the array does not perform deep copy
         public static void setStaticDateArray2(Date[] da) {
             sDateArray = da.clone();
         }
 
-        @ExpectWarning("MS")
         public static void setStaticValues(HashMap<Integer, String>  values) {
             shm = values;
         }
 
-        @ExpectWarning("MS")
         public static CharBuffer getStaticBuffer() {
             return sCharBuf;
         }
 
-        @ExpectWarning("MS")
         public static CharBuffer getStaticBufferDuplicate() {
             return sCharBuf.duplicate();
         }
 
-        @ExpectWarning("MS")
         public static CharBuffer getStaticBuferWrap() {
             return CharBuffer.wrap(sCharArray);        
         }
 
-        @ExpectWarning("MS")
         public static void setStaticBuffer(CharBuffer cb) {
             sCharBuf = cb;
         }
 
-        @ExpectWarning("MS")
         public static void setStaticBufferDuplicate(CharBuffer cb) {
             sCharBuf = cb.duplicate();
         }
 
-        @ExpectWarning("MS")
         public static void setStaticBufferWrap(char[] cArr) {
             sCharBuf = CharBuffer.wrap(cArr);
         }
 
-        @ExpectWarning("EI")
         public Date getDate() {
             return date;
         }
 
-        @ExpectWarning("EI") // Indirect way of returning reference
+        // Indirect way of returning reference
         public Date getDate2() {
             Date d = date;
             return d;
         }
 
-        @ExpectWarning("EI")
         public Date[] getDateArray() {
             return dateArray;
         }
 
-        @ExpectWarning("EI") // Cloning the array does not perform deep copy
+        // Cloning the array does not perform deep copy
         public Date[] getDateArray2() {
             return dateArray.clone();
         }
 
-        @ExpectWarning("EI")
         public HashMap<Integer, String> getValues() {
             return hm;
         }
 
-        @ExpectWarning("EI2")
         public void setDate(Date d) {
             date = d;
         }
 
         // Storing a reference to a mutable object is dangerous.
 
-        @ExpectWarning("EI2") // Indirect way of storing reference
+        // Indirect way of storing reference
         public void setDate2(Date d) {
             Date d2 = d;
             date = d2;
         }
 
-        @ExpectWarning("EI2")
         public void setDateArray(Date[] da) {
             dateArray = da;
         }
 
-        @ExpectWarning("EI2") // Cloning the array does not perform deep copy
+        // Cloning the array does not perform deep copy
         public void setDateArray2(Date[] da) {
             dateArray = da.clone();
         }
 
-        @ExpectWarning("EI2")
         public void setValues(HashMap<Integer, String> values) {
             hm = values;
         }
 
-        @ExpectWarning("EI")
         public CharBuffer getBuffer() {
             return charBuf;
         }
 
-        @ExpectWarning("EI")
         public CharBuffer getBufferDuplicate() {
             return charBuf.duplicate();
         }
 
-        @ExpectWarning("EI")
         public CharBuffer getBuferWrap() {
             return CharBuffer.wrap(charArray);        
         }
 
-        @ExpectWarning("EI2")
         public void setBuffer(CharBuffer cb) {
             charBuf = cb;
         }
 
-        @ExpectWarning("EI2")
         public void setBufferDuplicate(CharBuffer cb) {
             charBuf = cb.duplicate();
         }
 
-        @ExpectWarning("EI2")
         public void setBufferWrap(char[] cArr) {
             charBuf = CharBuffer.wrap(cArr);
         }


### PR DESCRIPTION
Rewrote the tests to the newer type and renamed a method parameter and field to be conform with the codebase.
The `./gradlew spotlessCheck build smokeTest` command runs successfully.
Otherwise, the original PR seems okay, but I will review it more thoroughly.

----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
